### PR TITLE
fix: PRSD-8717-double-scroll-bars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/spandigital/presidium-layouts-blog
 
 go 1.18
 
-require github.com/spandigital/presidium-layouts-base v0.7.0 // indirect
+require github.com/spandigital/presidium-layouts-base v0.7.1 // indirect

--- a/layouts/partials/navigation/root.html
+++ b/layouts/partials/navigation/root.html
@@ -4,7 +4,7 @@
 {{ $rootUrl := path.Clean $url.Path }}
 {{ $slugifyUrl := .Site.Params.slugifyUrl | default true }}
 
-<nav>
+<nav class="navbar">
   <div class="navbar-header">{{ partial "navigation/brand.html" . }} </div>
   <div class="navbar-items">
     {{ $roles := .Site.Params.roles.options | default slice }} {{ if and (gt (len $roles) 0) .Site.Params.show.role }}


### PR DESCRIPTION
## Description

This change fixes an issue where blogs were showing double scroll bars in the nav section.

## Issue
- https://spandigital.atlassian.net/browse/PRSDM-8717

## Screenshots

<img width="1261" height="490" alt="Screenshot 2025-08-04 at 13 37 47" src="https://github.com/user-attachments/assets/f6c7d74d-f39b-4dda-9335-939fb91f439d" />

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
