### PR TITLE
fix: PRSDM-10129 avoid double headings

### DIFF
--- a/layouts/partials/page/header.html
+++ b/layouts/partials/page/header.html
@@ -1,0 +1,2 @@
+{{/* Blog-specific page header - always hidden since frontmatter shows the title */}}
+{{ partial "common/dummy" . }}


### PR DESCRIPTION
## Description

page/header.html in the base theme renders an `<h1>` with the page title. In the blog context this causes a duplicate heading, since the blog post content already includes the title from the markdown. Overrides the partial with a dummy to suppress it, consistent with the existing override in article/title.html for the same reason.

## Issue
- [x] :clipboard: [PRSDM-10129](https://spandigital.atlassian.net/browse/PRSDM-10129)

## Screenshots

<img width="1512" height="982" alt="Screenshot 2026-02-21 at 6 29 46 p m" src="https://github.com/user-attachments/assets/cb8dbe57-8481-4a46-8f97-e6634ffc3aa9" />

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
