### PR TITLE
chore: replace old objects

### DIFF
--- a/layouts/shortcodes/employees.html
+++ b/layouts/shortcodes/employees.html
@@ -7,7 +7,7 @@
             <th>Grade</th>
             <th>Email</th>
         </tr>
-        {{ range $.Site.Data.employees }}
+        {{ range hugo.Data.employees }}
         <tr>
             <td> {{ .first_name }} </td>
             <td> {{ .last_name }} </td>


### PR DESCRIPTION
[PRSDM-10694](https://spandigital.atlassian.net/browse/PRSDM-10694)

Replace deprecated .Site.Data with Hugo v0.156.0+ equivalent

Hugo v0.156.0 deprecated .Site.Data, with removal planned in a future release.

- layouts/shortcodes/employees.html : .Site.Data -> hugo.Data

I made sure the chronicle builds but i think this shortcode is legacy.